### PR TITLE
feat: add Scalar struct and arithmetic operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ ark-ec = { version = "0.2" }
 ark-ff = { version = "0.2" }
 ark-serialize = { version = "0.2" }
 ark-ed-on-bls12-377 = {version = "0.2", features = ["r1cs"]}
+zeroize = { version = "1.4.1" }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/src/group.rs
+++ b/src/group.rs
@@ -270,9 +270,9 @@ impl Neg for Element {
 }
 
 impl<'b> MulAssign<&'b Scalar> for Element {
-    /// Scalar multiplication is performed through the implementation
-    /// of `MulAssign` on `EdwardsProjective` which is a type alias for
-    /// `GroupProjective<EdwardsParameters>`.
+    // Scalar multiplication is performed through the implementation
+    // of `MulAssign` on `EdwardsProjective` which is a type alias for
+    // `GroupProjective<EdwardsParameters>`.
     fn mul_assign(&mut self, point: &'b Scalar) {
         let mut p = self.inner;
         p *= point.inner;

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,13 +1,18 @@
+use core::ops::Neg;
+use core::ops::{Add, AddAssign};
+use core::ops::{Mul, MulAssign};
+use core::ops::{Sub, SubAssign};
 use std::convert::{TryFrom, TryInto};
 
+use ark_ec::models::twisted_edwards_extended::GroupProjective;
 use ark_ec::models::TEModelParameters;
 use ark_ed_on_bls12_377::{EdwardsParameters, EdwardsProjective, Fq};
 use ark_ff::{Field, One, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
-use crate::{invsqrt::SqrtRatioZeta, sign::Sign, EncodingError};
+use zeroize::Zeroize;
 
-use ark_ec::models::twisted_edwards_extended::GroupProjective;
+use crate::{invsqrt::SqrtRatioZeta, scalar::Scalar, sign::Sign, EncodingError};
 
 trait OnCurve {
     fn is_on_curve(&self) -> bool;
@@ -51,6 +56,12 @@ impl PartialEq for Element {
 }
 
 impl Eq for Element {}
+
+impl Zeroize for Element {
+    fn zeroize(&mut self) {
+        self.inner.zeroize()
+    }
+}
 
 impl Element {
     #[allow(non_snake_case)]
@@ -213,6 +224,71 @@ impl CanonicalDeserialize for Element {
 ////////////////////////////////////////////////////////////////////////////////
 // Group operations
 ////////////////////////////////////////////////////////////////////////////////
+
+impl<'b> Add<&'b Element> for Element {
+    type Output = Element;
+
+    fn add(self, other: &'b Element) -> Element {
+        Element {
+            inner: self.inner + other.inner,
+        }
+    }
+}
+
+impl<'b> AddAssign<&'b Element> for Element {
+    fn add_assign(&mut self, other: &'b Element) {
+        *self = Element {
+            inner: self.inner + other.inner,
+        }
+    }
+}
+
+impl<'b> Sub<&'b Element> for Element {
+    type Output = Element;
+
+    fn sub(self, other: &'b Element) -> Element {
+        Self {
+            inner: self.inner - other.inner,
+        }
+    }
+}
+
+impl<'b> SubAssign<&'b Element> for Element {
+    fn sub_assign(&mut self, other: &'b Element) {
+        *self = Element {
+            inner: self.inner - other.inner,
+        }
+    }
+}
+
+impl Neg for Element {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Element { inner: -self.inner }
+    }
+}
+
+impl<'b> MulAssign<&'b Scalar> for Element {
+    /// Scalar multiplication is performed through the implementation
+    /// of `MulAssign` on `EdwardsProjective` which is a type alias for
+    /// `GroupProjective<EdwardsParameters>`.
+    fn mul_assign(&mut self, point: &'b Scalar) {
+        let mut p = self.inner;
+        p *= point.inner;
+        *self = Element { inner: p }
+    }
+}
+
+impl<'b> Mul<&'b Scalar> for Element {
+    type Output = Element;
+
+    fn mul(self, point: &'b Scalar) -> Element {
+        let mut p = self.inner;
+        p *= point.inner;
+        Element { inner: p }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 mod error;
 mod group;
 mod invsqrt;
+mod scalar;
 mod sign;
 
 pub use error::EncodingError;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -3,6 +3,7 @@ use core::ops::{Add, AddAssign};
 use core::ops::{Mul, MulAssign};
 use core::ops::{Sub, SubAssign};
 
+use ark_ff::Zero;
 use zeroize::Zeroize;
 
 /// `Scalar` Represents an integer value.
@@ -10,7 +11,13 @@ pub struct Scalar {
     pub(crate) inner: ark_ed_on_bls12_377::Fr,
 }
 
-// TODO: Methods to instantiate Scalar
+impl Default for Scalar {
+    fn default() -> Self {
+        Scalar {
+            inner: ark_ed_on_bls12_377::Fr::zero(),
+        }
+    }
+}
 
 impl Zeroize for Scalar {
     fn zeroize(&mut self) {

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,0 +1,87 @@
+use core::ops::Neg;
+use core::ops::{Add, AddAssign};
+use core::ops::{Mul, MulAssign};
+use core::ops::{Sub, SubAssign};
+
+use zeroize::Zeroize;
+
+/// `Scalar` Represents an integer value.
+pub struct Scalar {
+    pub(crate) inner: ark_ed_on_bls12_377::Fr,
+}
+
+// TODO: Methods to instantiate Scalar
+
+impl Zeroize for Scalar {
+    fn zeroize(&mut self) {
+        self.inner.zeroize();
+    }
+}
+
+impl PartialEq for Scalar {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<'b> Add<&'b Scalar> for Scalar {
+    type Output = Scalar;
+
+    fn add(self, other: &'b Scalar) -> Scalar {
+        Scalar {
+            inner: self.inner + other.inner,
+        }
+    }
+}
+
+impl<'b> AddAssign<&'b Scalar> for Scalar {
+    fn add_assign(&mut self, other: &'b Scalar) {
+        *self = Scalar {
+            inner: self.inner + other.inner,
+        }
+    }
+}
+
+impl<'b> Sub<&'b Scalar> for Scalar {
+    type Output = Scalar;
+
+    fn sub(self, other: &'b Scalar) -> Scalar {
+        Self {
+            inner: self.inner - other.inner,
+        }
+    }
+}
+
+impl<'b> SubAssign<&'b Scalar> for Scalar {
+    fn sub_assign(&mut self, other: &'b Scalar) {
+        *self = Scalar {
+            inner: self.inner - other.inner,
+        }
+    }
+}
+
+impl<'b> Mul<&'b Scalar> for Scalar {
+    type Output = Scalar;
+
+    fn mul(self, other: &'b Scalar) -> Scalar {
+        Scalar {
+            inner: self.inner * other.inner,
+        }
+    }
+}
+
+impl<'b> MulAssign<&'b Scalar> for Scalar {
+    fn mul_assign(&mut self, other: &'b Scalar) {
+        *self = Scalar {
+            inner: self.inner * other.inner,
+        }
+    }
+}
+
+impl Neg for Scalar {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Scalar { inner: -self.inner }
+    }
+}


### PR DESCRIPTION
This PR adds a `Scalar` struct and basic arithmetic operations for `Element` and `Scalar`

Next steps:
- [ ] Various methods to instantiate Scalar
- [ ] The `define_mul_variants` and friends macros from `curve25519_dalek` are pretty handy, I plan to take that approach since it makes implementing `MulAssign<Element> for Scalar` and `Mul<Element> for Scalar` a bit cleaner, which are nice to have for ergonomics
- [ ] Hash to group 