### PR TITLE
Re-export Fq as well as Fr.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,4 @@ pub use error::EncodingError;
 pub use group::{Element, Encoding};
 
 pub use ark_ed_on_bls12_377::Fr;
+pub use ark_ed_on_bls12_377::Fq;


### PR DESCRIPTION
Going forward we should think about whether or not (or more realistically, to
what degree) we want to expose this stuff in the public API, but this is used
by the Elligator functionality now and doesn't add any additional API surface
over the existing Fr re-export.