### PR TITLE
Export the `Scalar` type so that scalar mul is accessible.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,5 +11,7 @@ mod sign;
 pub use error::EncodingError;
 pub use group::{Element, Encoding};
 
+pub use scalar::Scalar;
+
 pub use ark_ed_on_bls12_377::Fq;
 pub use ark_ed_on_bls12_377::Fr;


### PR DESCRIPTION
Going forward, we should probably settle on a common scalar type.