### PR TITLE
Move `Element::basepoint()` to be a bare method

### DIFF
--- a/src/element.rs
+++ b/src/element.rs
@@ -4,7 +4,7 @@ use ark_ed_on_bls12_377::EdwardsProjective;
 use ark_ff::Zero;
 use zeroize::Zeroize;
 
-use crate::{Encoding, Fr};
+use crate::Fr;
 
 #[derive(Copy, Clone)]
 pub struct Element {
@@ -46,16 +46,6 @@ impl Zeroize for Element {
 }
 
 impl Element {
-    /// Return the conventional generator for `decaf377`.
-    pub fn basepoint() -> Element {
-        let mut bytes = [0u8; 32];
-        bytes[0] = 8;
-
-        Encoding(bytes)
-            .decompress()
-            .expect("hardcoded basepoint bytes are valid")
-    }
-
     /// Convenience method to make identity checks more readable.
     pub fn is_identity(&self) -> bool {
         self == &Element::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,13 @@ pub use ark_ed_on_bls12_377::{Fq, Fr};
 use invsqrt::SqrtRatioZeta;
 use on_curve::OnCurve;
 use sign::Sign;
+
+/// Return the conventional generator for `decaf377`.
+pub fn basepoint() -> Element {
+    let mut bytes = [0u8; 32];
+    bytes[0] = 8;
+
+    Encoding(bytes)
+        .decompress()
+        .expect("hardcoded basepoint bytes are valid")
+}

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use proptest::prelude::*;
 
-use decaf377::{Element, Encoding, Fr, FrExt};
+use decaf377::{basepoint, Element, Encoding, Fr, FrExt};
 
 #[test]
 fn identity_encoding_is_zero() {
@@ -36,7 +36,7 @@ fn test_encoding_matches_sage_encoding() {
     use hex;
 
     let mut accumulator = Element::default();
-    let basepoint = Element::basepoint();
+    let basepoint = basepoint();
 
     let expected_points = [
         "0000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
This makes it a little more ergonomic to use in the common case where the crate
name is used as a prefix.

Closes #18