### PR TITLE
deps: remove pinned arkworks dependencies, use 0.3.x from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,3 @@ zeroize = "1.4"
 
 [dev-dependencies]
 proptest = "1"
-
-[patch.crates-io]
-# The "ours" branch is based off of v0.3.0
-ark-ff = { git = "https://github.com/penumbra-zone/algebra", branch = "ours" }
-ark-serialize = { git = "https://github.com/penumbra-zone/algebra", branch = "ours" }


### PR DESCRIPTION
Remove pinned git dependencies, towards https://github.com/penumbra-zone/penumbra/issues/713

0.3.0 is the latest release for `ark-ff`. The branch we were using was based on `0.3.0` and consisted of two changes, one which has been merged upstream (commit 6e568cdaf154806365823d48d547b3864412a516) but not included in a release yet, and one that's still outstanding (https://github.com/arkworks-rs/algebra/pull/322) but IIRC we were only using for debugging purposes. 