### PR TITLE
export `Bls12_377` parameter struct (implements `PairingEngine`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ ark-std = "0.3"
 ark-ec = "0.3"
 ark-ff = "0.3"
 ark-serialize = "0.3"
+ark-bls12-377 = "0.3"
 ark-ed-on-bls12-377 = { version = "0.3", features = ["r1cs"] }
 zeroize = "1.4"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub use encoding::Encoding;
 pub use error::EncodingError;
 pub use field_ext::FieldExt;
 
+pub use ark_bls12_377::Bls12_377;
 pub use ark_ed_on_bls12_377::{Fq, Fr};
 
 use invsqrt::SqrtRatioZeta;


### PR DESCRIPTION
We need to export this parameter struct in general for proof support and in particular for https://github.com/penumbra-zone/penumbra/issues/711 since the [`KZG10`](https://docs.rs/ark-poly-commit/latest/ark_poly_commit/kzg10/struct.KZG10.html#impl) polynomial commitment scheme needs a `PairingEngine`