### PR TITLE
fix: call `LazyElementVar::encoding` when doing compress to curve

### DIFF
--- a/src/r1cs/element.rs
+++ b/src/r1cs/element.rs
@@ -25,7 +25,7 @@ pub struct ElementVar {
 impl ElementVar {
     /// R1CS equivalent of `Element::vartime_compress_to_field`
     pub fn compress_to_field(&self) -> Result<FqVar, SynthesisError> {
-        self.inner.element()?.compress_to_field()
+        self.inner.encoding()
     }
 
     /// R1CS equivalent of `Encoding::vartime_decompress`


### PR DESCRIPTION
Followup to #42. When we are doing compress to field, we should not pass through to the inner `Element`, instead we should be calling `LazyElementVar::encoding()` to fetch the `FqVar` if already has been created, and only calling `Element::compress_to_field()` if it doesn't exist.