### PR TITLE
fix: rework encoding of public inputs

### DIFF
--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -31,6 +31,6 @@ impl<T> CountConstraints for T where T: ConstraintSynthesizer<Fq> + Sized {}
 
 impl ToConstraintField<Fq> for Element {
     fn to_field_elements(&self) -> Option<Vec<Fq>> {
-        self.inner.to_field_elements()
+        Some([self.vartime_compress_to_field()].to_vec())
     }
 }

--- a/src/r1cs/element.rs
+++ b/src/r1cs/element.rs
@@ -150,6 +150,21 @@ impl AllocVar<AffineElement, Fq> for ElementVar {
     }
 }
 
+impl AllocVar<Fq, Fq> for ElementVar {
+    fn new_variable<T: Borrow<Fq>>(
+        cs: impl Into<ark_relations::r1cs::Namespace<Fq>>,
+        f: impl FnOnce() -> Result<T, SynthesisError>,
+        mode: AllocationMode,
+    ) -> Result<Self, SynthesisError> {
+        let ns = cs.into();
+        let cs = ns.cs();
+        let inner = InnerElementVar::new_variable(cs, f, mode)?;
+        Ok(Self {
+            inner: LazyElementVar::new_from_element(inner),
+        })
+    }
+}
+
 impl ToBitsGadget<Fq> for ElementVar {
     fn to_bits_le(&self) -> Result<Vec<Boolean<Fq>>, SynthesisError> {
         let compressed_fq = self

--- a/src/r1cs/inner.rs
+++ b/src/r1cs/inner.rs
@@ -226,6 +226,37 @@ impl CondSelectGadget<Fq> for ElementVar {
     }
 }
 
+impl AllocVar<Fq, Fq> for ElementVar {
+    fn new_variable<T: std::borrow::Borrow<Fq>>(
+        cs: impl Into<ark_relations::r1cs::Namespace<Fq>>,
+        f: impl FnOnce() -> Result<T, SynthesisError>,
+        mode: AllocationMode,
+    ) -> Result<Self, SynthesisError> {
+        let ns = cs.into();
+        let cs = ns.cs();
+        let f = || Ok(*f()?.borrow());
+        let field_element = f()?;
+
+        // `new_variable` should *not* allocate any new variables or constraints in `cs` when
+        // the mode is `AllocationMode::Constant` (see `AllocVar::new_constant`).
+        match mode {
+            AllocationMode::Constant => unimplemented!(),
+            AllocationMode::Input => {
+                // 1. Witness the encoded value
+                let compressed_P_var = FqVar::new_input(cs, || Ok(field_element))?;
+
+                // 3. Decode (in circuit)
+                let decoded_var = ElementVar::decompress_from_field(compressed_P_var)?;
+
+                Ok(decoded_var)
+            }
+            AllocationMode::Witness => {
+                unimplemented!()
+            }
+        }
+    }
+}
+
 // This lets us use `new_constant`, `new_input` (public), or `new_witness` to add
 // decaf elements to an R1CS constraint system.
 impl AllocVar<Element, Fq> for ElementVar {
@@ -253,33 +284,7 @@ impl AllocVar<Element, Fq> for ElementVar {
                 )?,
             }),
             AllocationMode::Input => {
-                // let P_var = AffineVar::new_variable_omit_prime_order_check(
-                //     ns!(cs, "P_affine"),
-                //     || Ok(group_projective_point.inner),
-                //     mode,
-                // )?;
-
-                // At this point `P_var` might not be a valid representative of a decaf point.
-                //
-                // One way that is secure but provides stronger constraints than we need:
-                //
-                // 1. Encode (out of circuit) to an Fq
-                let field_element = group_projective_point.vartime_compress_to_field();
-
-                // 2. Witness the encoded value
-                let compressed_P_var = FqVar::new_input(cs.clone(), || Ok(field_element))?;
-
-                // 3. Decode (in circuit)
-                let decoded_var = ElementVar::decompress_from_field(compressed_P_var)?;
-
-                Ok(decoded_var)
-                // Ok(Self {
-                //     inner: EdwardsVar::new_variable_omit_prime_order_check(
-                //         cs,
-                //         || Ok(group_projective_point.inner),
-                //         mode,
-                //     )?,
-                // })
+                unimplemented!()
             }
             AllocationMode::Witness => {
                 //let ge: EdwardsAffine = group_projective_point.inner.into();

--- a/tests/groth16_gadgets.rs
+++ b/tests/groth16_gadgets.rs
@@ -41,7 +41,8 @@ impl ConstraintSynthesizer<Fq> for DiscreteLogCircuit {
         let witness_vars = UInt8::new_witness_vec(cs.clone(), &self.scalar)?;
 
         // 2. Add public input variable
-        let public_var = ElementVar::new_input(cs.clone(), || Ok(self.public))?;
+        let compressed_public = self.public.vartime_compress_to_field();
+        let public_var: ElementVar = AllocVar::new_input(cs.clone(), || Ok(compressed_public))?;
         let basepoint_var = ElementVar::new_constant(cs, basepoint())?;
         // 3. Add constraint that scalar * Basepoint = public
         let test_public = basepoint_var.scalar_mul_le(witness_vars.to_bits_le()?.iter())?;
@@ -247,7 +248,8 @@ impl ConstraintSynthesizer<Fq> for DecompressionCircuit {
         let witness_var = FqVar::new_witness(cs.clone(), || Ok(self.field_element))?;
 
         // 2. Add public input variable
-        let public_var = ElementVar::new_input(cs, || Ok(self.point))?;
+        let compressed_public = self.point.vartime_compress_to_field();
+        let public_var: ElementVar = AllocVar::new_input(cs, || Ok(compressed_public))?;
 
         // 3. Add decompression constraints
         let test_public = ElementVar::decompress_from_field(witness_var)?;
@@ -347,7 +349,8 @@ impl ConstraintSynthesizer<Fq> for ElligatorCircuit {
         let witness_var = FqVar::new_witness(cs.clone(), || Ok(self.field_element))?;
 
         // 2. Add public input variable
-        let public_var = ElementVar::new_input(cs, || Ok(self.point))?;
+        let compressed_public = self.point.vartime_compress_to_field();
+        let public_var: ElementVar = AllocVar::new_input(cs, || Ok(compressed_public))?;
 
         // 3. Add elligator constraints
         let test_public = ElementVar::encode_to_curve(&witness_var)?;
@@ -445,7 +448,8 @@ impl ConstraintSynthesizer<Fq> for PublicElementInput {
         cs: ark_relations::r1cs::ConstraintSystemRef<Fq>,
     ) -> ark_relations::r1cs::Result<()> {
         // 1. Add public input variable
-        let _public_var = ElementVar::new_input(cs, || Ok(self.point))?;
+        let compressed_public = self.point.vartime_compress_to_field();
+        let _public_var: ElementVar = AllocVar::new_input(cs, || Ok(compressed_public))?;
 
         Ok(())
     }


### PR DESCRIPTION
This change expects `ElementVar` public inputs to always be allocated from the compressed representation (i.e. an `Fq`)

Towards https://github.com/penumbra-zone/penumbra/issues/2041

Smoke tests now pass when https://github.com/penumbra-zone/penumbra/pull/2046 is built using this branch