### PR TITLE
disable default internal parallelism (rayon)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@
 # 0.2.0
 
 * Fix: Use compressed representation for public elements in-circuit.
+
+# 0.3.0
+
+* Disable internal parallelism

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,19 +17,24 @@ tracing = "0.1"
 tracing-subscriber = "0.2"
 anyhow = "1.0"
 ark-relations = "0.3"
-ark-r1cs-std = {version = "0.3", optional=true }
-ark-std = "0.3"
-ark-ec = "0.3"
-ark-ff = "0.3"
+ark-r1cs-std = { version = "0.3", optional=true, default-features=false }
+ark-std = { version = "0.3", default-features=false }
+ark-ec = { version = "0.3", default-features=false }
+ark-ff =  { version = "0.3", default-features=false }
 ark-serialize = "0.3"
 ark-bls12-377 = "0.3"
 ark-ed-on-bls12-377 = { version = "0.3", features = ["r1cs"] }
-ark-groth16 = { version = "0.3", optional=true }
+ark-groth16 = { version = "0.3", default-features=false, optional=true }
 ark-snark = { version = "0.3", optional=true }
 zeroize = "1.4"
 
+# This matches what ark-std (a library for no_std compatibility) does, having
+# a default feature of std - without the ark-std std feature, decaf377 doesn't
+# compile
 [features]
-default = []
+default = ["std"]
+std = ["ark-std/std"]
+fast-proofs = ["ark-ff/parallel", "ark-ec/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel"]
 r1cs = ["ark-r1cs-std", "ark-groth16", "ark-snark"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decaf377"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Henry de Valence <hdevalence@hdevalence.ca>", "redshiftzero <jen@penumbra.zone>"]
 description = "A prime-order group designed for use in SNARKs over BLS12-377"
 edition = "2018"
@@ -34,7 +34,7 @@ zeroize = "1.4"
 [features]
 default = ["std"]
 std = ["ark-std/std"]
-fast-proofs = ["ark-ff/parallel", "ark-ec/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel"]
+parallel = ["ark-ff/parallel", "ark-ec/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel"]
 r1cs = ["ark-r1cs-std", "ark-groth16", "ark-snark"]
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ functionality, and works the same way inside and outside of a circuit.
 More details are available on the [Penumbra
 website](https://protocol.penumbra.zone/main/crypto/decaf377.html).
 
+## Features
+
+* `std`: default, for use in `std` environments,
+* `r1cs`: enables rank-1 constraint system gadgets,
+* `parallel`: enables the use of parallelism.
+
 ## Benchmarks
 
 Run `criterion` benchmarks using:


### PR DESCRIPTION
For https://github.com/penumbra-zone/penumbra/issues/2124

Note that this adds a default feature - "std" - which turns on the default "std" feature from the ark-std crate: https://github.com/arkworks-rs/std/blob/v0.3.0/Cargo.toml#L22

The other two features here are:
* `parallel`: turns on parallelism when using r1cs gadgets
* `r1cs`: just enables r1cs gadgets _without_ turning on parallelism
