### PR TITLE
r1cs: remove unnecessary loop in sign check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,7 @@
 # 0.4.0
 
 * Upgrade to 0.4.x series of Arkworks dependencies.
+
+# Unreleased
+
+* R1CS: remove 7 unnecessary constraints in the sign checks.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decaf377"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Henry de Valence <hdevalence@hdevalence.ca>", "redshiftzero <jen@penumbralabs.xyz>"]
 description = "A prime-order group designed for use in SNARKs over BLS12-377"
 edition = "2018"

--- a/src/r1cs/fqvar_ext.rs
+++ b/src/r1cs/fqvar_ext.rs
@@ -80,13 +80,11 @@ impl FqVarExtension for FqVar {
         // bytes[0] & 1 == 0
         let true_var = Boolean::<Fq>::TRUE;
         let false_var = Boolean::<Fq>::FALSE;
-        let mut is_nonnegative_var = true_var.clone();
-        // Check first 8 bits
-        for _ in 0..8 {
-            let lhs = bitvars[0].and(&true_var.clone())?;
-            let this_loop_var = lhs.is_eq(&false_var)?;
-            is_nonnegative_var = is_nonnegative_var.and(&this_loop_var)?;
-        }
+
+        // Check least significant bit
+        let lhs = bitvars[0].and(&true_var)?;
+        let is_nonnegative_var = lhs.is_eq(&false_var)?;
+
         Ok(is_nonnegative_var)
     }
 


### PR DESCRIPTION
There is an unnecessary loop in the decaf377 element's sign checks in R1CS, which adds an additional 7 constraints (so this is a circuit-breaking change). 