### PR TITLE
add negate method to Element

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -84,6 +84,10 @@ impl Encoding {
 }
 
 impl Element {
+    pub fn negate(&self) -> Element {
+        Element { inner: -self.inner }
+    }
+
     #[deprecated(note = "please use `vartime_compress_to_field` instead")]
     pub fn compress_to_field(&self) -> Fq {
         self.vartime_compress_to_field()


### PR DESCRIPTION
This PR:
* adds a `negate` method to the OOC `Element`
* adds a test checking consistency between the OOC and R1CS element negation