### PR TITLE
fix: R1CS `SubAssign` and `AddAssign`

### DIFF
--- a/src/r1cs/inner.rs
+++ b/src/r1cs/inner.rs
@@ -333,10 +333,7 @@ impl<'a> Add<&'a ElementVar> for ElementVar {
 
 impl AddAssign for ElementVar {
     fn add_assign(&mut self, rhs: ElementVar) {
-        dbg!("inner.rs: impl AddAssign for ElementVar");
-        dbg!(self.inner.value());
-        let result = self.inner.add_assign(rhs.inner);
-        dbg!(self.inner.value());
+        self.inner.add_assign(rhs.inner);
     }
 }
 

--- a/src/r1cs/inner.rs
+++ b/src/r1cs/inner.rs
@@ -333,7 +333,10 @@ impl<'a> Add<&'a ElementVar> for ElementVar {
 
 impl AddAssign for ElementVar {
     fn add_assign(&mut self, rhs: ElementVar) {
-        self.inner.add_assign(rhs.inner)
+        dbg!("inner.rs: impl AddAssign for ElementVar");
+        dbg!(self.inner.value());
+        let result = self.inner.add_assign(rhs.inner);
+        dbg!(self.inner.value());
     }
 }
 

--- a/src/r1cs/ops.rs
+++ b/src/r1cs/ops.rs
@@ -1,5 +1,7 @@
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
+use ark_r1cs_std::R1CSVar;
+
 use crate::{r1cs::element::ElementVar, Element};
 
 use super::lazy::LazyElementVar;
@@ -36,15 +38,24 @@ impl<'a> Add<&'a ElementVar> for ElementVar {
 
 impl AddAssign for ElementVar {
     fn add_assign(&mut self, rhs: ElementVar) {
+        dbg!("inside impl AddAssign for ElementVar");
+        dbg!(self.inner.element().unwrap().value());
+
+        let rhs = rhs.inner.element().expect("element will exist");
         self.inner
             .element()
             .expect("element will exist")
-            .add_assign(rhs.inner.element().expect("element will exist"));
+            .add_assign(rhs);
+
+        // BUG: inner element not being updated here?
+
+        dbg!(self.inner.element().unwrap().value());
     }
 }
 
 impl<'a> AddAssign<&'a ElementVar> for ElementVar {
     fn add_assign(&mut self, rhs: &'a ElementVar) {
+        dbg!("inside impl<'a> AddAssign<&'a ElementVar> for ElementVar ");
         self.inner
             .element()
             .expect("element will exist")

--- a/src/r1cs/ops.rs
+++ b/src/r1cs/ops.rs
@@ -1,7 +1,5 @@
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
-use ark_r1cs_std::R1CSVar;
-
 use crate::{r1cs::element::ElementVar, Element};
 
 use super::lazy::LazyElementVar;
@@ -38,28 +36,25 @@ impl<'a> Add<&'a ElementVar> for ElementVar {
 
 impl AddAssign for ElementVar {
     fn add_assign(&mut self, rhs: ElementVar) {
-        dbg!("inside impl AddAssign for ElementVar");
-        dbg!(self.inner.element().unwrap().value());
-
         let rhs = rhs.inner.element().expect("element will exist");
-        self.inner
-            .element()
-            .expect("element will exist")
-            .add_assign(rhs);
+        let mut lhs = self.inner.element().expect("element will exist");
+        lhs.add_assign(rhs);
 
-        // BUG: inner element not being updated here?
-
-        dbg!(self.inner.element().unwrap().value());
+        *self = ElementVar {
+            inner: LazyElementVar::new_from_element(lhs),
+        };
     }
 }
 
 impl<'a> AddAssign<&'a ElementVar> for ElementVar {
     fn add_assign(&mut self, rhs: &'a ElementVar) {
-        dbg!("inside impl<'a> AddAssign<&'a ElementVar> for ElementVar ");
-        self.inner
-            .element()
-            .expect("element will exist")
-            .add_assign(rhs.inner.element().expect("element will exist"));
+        let rhs = rhs.inner.element().expect("element will exist");
+        let mut lhs = self.inner.element().expect("element will exist");
+        lhs.add_assign(rhs);
+
+        *self = ElementVar {
+            inner: LazyElementVar::new_from_element(lhs),
+        };
     }
 }
 
@@ -95,19 +90,25 @@ impl<'a> Sub<&'a ElementVar> for ElementVar {
 
 impl SubAssign for ElementVar {
     fn sub_assign(&mut self, rhs: ElementVar) {
-        self.inner
-            .element()
-            .expect("element will exist")
-            .sub_assign(rhs.inner.element().expect("element will exist"));
+        let rhs = rhs.inner.element().expect("element will exist");
+        let mut lhs = self.inner.element().expect("element will exist");
+        lhs.sub_assign(rhs);
+
+        *self = ElementVar {
+            inner: LazyElementVar::new_from_element(lhs),
+        };
     }
 }
 
 impl<'a> SubAssign<&'a ElementVar> for ElementVar {
     fn sub_assign(&mut self, rhs: &'a ElementVar) {
-        self.inner
-            .element()
-            .expect("element will exist")
-            .sub_assign(rhs.inner.element().expect("element will exist"));
+        let rhs = rhs.inner.element().expect("element will exist");
+        let mut lhs = self.inner.element().expect("element will exist");
+        lhs.sub_assign(rhs);
+
+        *self = ElementVar {
+            inner: LazyElementVar::new_from_element(lhs),
+        };
     }
 }
 
@@ -125,10 +126,12 @@ impl Sub<Element> for ElementVar {
 
 impl SubAssign<Element> for ElementVar {
     fn sub_assign(&mut self, rhs: Element) {
-        self.inner
-            .element()
-            .expect("element will exist")
-            .sub_assign(rhs)
+        let mut lhs = self.inner.element().expect("element will exist");
+        lhs.sub_assign(rhs);
+
+        *self = ElementVar {
+            inner: LazyElementVar::new_from_element(lhs),
+        };
     }
 }
 
@@ -146,9 +149,11 @@ impl Add<Element> for ElementVar {
 
 impl AddAssign<Element> for ElementVar {
     fn add_assign(&mut self, rhs: Element) {
-        self.inner
-            .element()
-            .expect("element will exist")
-            .add_assign(rhs)
+        let mut lhs = self.inner.element().expect("element will exist");
+        lhs.add_assign(rhs);
+
+        *self = ElementVar {
+            inner: LazyElementVar::new_from_element(lhs),
+        };
     }
 }

--- a/tests/groth16_gadgets.rs
+++ b/tests/groth16_gadgets.rs
@@ -5,7 +5,7 @@ use proptest::prelude::*;
 use ark_r1cs_std::{
     prelude::{AllocVar, CurveVar, EqGadget},
     uint8::UInt8,
-    ToBitsGadget,
+    R1CSVar, ToBitsGadget,
 };
 use ark_relations::r1cs::{ConstraintSynthesizer, ToConstraintField};
 use ark_snark::SNARK;
@@ -547,10 +547,10 @@ fn groth16_negation(point in element_strategy()) {
 #[derive(Clone)]
 struct AddAssignAddCircuit {
     // Witness
-    a: Element,
-    b: Element,
+    a: Fq,
+    b: Fq,
 
-    pub c: Element,
+    pub c: Fq,
 }
 
 impl ConstraintSynthesizer<Fq> for AddAssignAddCircuit {
@@ -558,16 +558,20 @@ impl ConstraintSynthesizer<Fq> for AddAssignAddCircuit {
         self,
         cs: ark_relations::r1cs::ConstraintSystemRef<Fq>,
     ) -> ark_relations::r1cs::Result<()> {
-        let a = ElementVar::new_witness(cs.clone(), || Ok(self.a))?;
-        let b = ElementVar::new_witness(cs.clone(), || Ok(self.b))?;
+        let a = FqVar::new_witness(cs.clone(), || Ok(self.a))?;
+        let b = FqVar::new_witness(cs.clone(), || Ok(self.b))?;
 
-        let c_pub = ElementVar::new_input(cs, || Ok(self.c))?;
+        let c_pub = FqVar::new_input(cs, || Ok(self.c))?;
         let c_add = a.clone() + b.clone();
-        let mut c_add_assign = a;
+        let mut c_add_assign = a.clone();
+        dbg!(a.value());
         c_add_assign += b;
 
+        dbg!(c_pub.value());
         c_add.enforce_equal(&c_pub)?;
+        dbg!(c_add.value());
         c_add_assign.enforce_equal(&c_pub)?;
+        dbg!(c_add_assign.value());
 
         Ok(())
     }
@@ -576,11 +580,11 @@ impl ConstraintSynthesizer<Fq> for AddAssignAddCircuit {
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
 #[test]
-fn groth16_add_addassign(a in element_strategy(), b in element_strategy()) {
+fn groth16_add_addassign(a in fq_strategy(), b in fq_strategy()) {
     let test_circuit = AddAssignAddCircuit {
-        a: decaf377::basepoint(),
-        b: decaf377::basepoint() * Fr::from(2),
-        c: decaf377::basepoint() * Fr::from(3),
+        a: Fq::from(1),
+        b: Fq::from(2),
+        c: Fq::from(3),
     };
     let (pk, vk) = Groth16::<Bls12_377, LibsnarkReduction>::circuit_specific_setup(test_circuit, &mut OsRng)
         .expect("can perform circuit specific setup");
@@ -592,6 +596,12 @@ fn groth16_add_addassign(a in element_strategy(), b in element_strategy()) {
         b,
         c: a + b,
     };
+    let c_add_ooc = a + b;
+    dbg!(c_add_ooc);
+    let mut c_add_assign_ooc = a;
+    c_add_assign_ooc += b;
+    dbg!(c_add_assign_ooc);
+
     let proof: Proof<Bls12_377> = Groth16::<Bls12_377, LibsnarkReduction>::prove(&pk, circuit, &mut rng)
         .map_err(|_| anyhow::anyhow!("invalid proof"))
         .expect("can generate proof");


### PR DESCRIPTION
Closes #56