### PR TITLE
ci: add job building with no alloc feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,23 @@ jobs:
           command: test
           args: --features ${{ matrix.backend }}
 
+  build_no_alloc:
+    name: build without alloc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup target add thumbv7em-none-eabihf
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target thumbv7em-none-eabihf --no-default-features
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 # no-alloc, no-std
 cfg-if = "1.0"
 hex = { version ="=0.4.2", default-features = false }
-subtle = "2.5"
+subtle = { version="2.5", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 zeroize = { version = "1.7", default-features = false }
 # no-std
@@ -39,7 +39,7 @@ once_cell = { version= "1.8", optional = true, default-features = false }
 [features]
 default = ["arkworks"]
 alloc = ["once_cell/alloc", "tracing-subscriber/alloc", "zeroize/alloc"]
-std = ["alloc", "tracing/std", "anyhow/std", "tracing-subscriber/std", "zeroize/std", "once_cell/std", "num-bigint/std", "hex/std"]
+std = ["alloc", "tracing/std", "anyhow/std", "tracing-subscriber/std", "zeroize/std", "once_cell/std", "num-bigint/std", "hex/std", "subtle/std"]
 parallel = ["ark-ff/parallel", "ark-ec/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel"]
 # TODO: eventually, feature-gate all arkworks deps behind this feature.
 arkworks = ["std", "ark-std", "ark-ec", "ark-ff", "ark-serialize", "ark-bls12-377", "ark-ed-on-bls12-377"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # no-alloc, no-std
 cfg-if = "1.0"
-hex = { version ="=0.4.2", default-features = false } 
-once_cell = { version= "1.8", default-features = false }
+hex = { version ="=0.4.2", default-features = false }
 subtle = "2.5"
 tracing-subscriber = { version = "0.3", default-features = false }
 zeroize = { version = "1.7", default-features = false }
@@ -32,6 +31,7 @@ ark-bls12-377 = { version = "0.4", optional = true }
 ark-ed-on-bls12-377 = { version = "0.4", optional = true }
 ark-groth16 = { version = "0.4", optional = true }
 ark-snark = { version = "0.4", optional = true }
+once_cell = { version= "1.8", optional = true, default-features = false }
 
 # This matches what ark-std (a library for no_std compatibility) does, having
 # a default feature of std - without the ark-std std feature, decaf377 doesn't


### PR DESCRIPTION
Closes #70
This adds a job that builds on a platform (`thumbv7em-none-eabihf`) without `std` or `alloc`. I had to make a couple of small dependency changes (see commits) to get successful compilation. 