### PR TITLE
ci: use larger runners

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -20,7 +20,7 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: ubuntu-latest
+    runs-on: buildjet-16vcpu-ubuntu-2204
     # We want to run the tests twice, once with the
     # default backend (u64) and one with the u32_backend,
     # in both cases with the r1cs feature enabled.
@@ -28,23 +28,23 @@ jobs:
       matrix:
         backend: ["r1cs", "r1cs,u32_backend"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features ${{ matrix.backend }}
+      - uses: actions/checkout@v4
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - name: Load rust cache
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
+      - name: Run tests with nextest
+        run: cargo nextest run --features ${{ matrix.backend }}
+        env:
+          CARGO_TERM_COLOR: always
 
   build_no_alloc:
     name: build without alloc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -61,7 +61,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -78,7 +78,7 @@ jobs:
     name: no_std compatibility check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
The longest running CI jobs are the test suite, predictably. Before this change, runtimes were:

  * 26m for r1cs
  * 1h26m for r1cs,u32_backend

The other, non-test-suite jobs are all sub-minute, likely due to caching. To get runtimes down, we:

  * use larger buildjet runners with more vcpus
  * switch from "cargo test" to "cargo nextest"
  * update caching logic to use the astria helper (significantly more headroom on caches)