### PR TITLE
ci: dedicated profile for release + debug_assert

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+[profile.ci]
+# Using recommended settings from https://nexte.st/book/configuration.html#profiles
+failure-output = "immediate-final"
+fail-fast = false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Load rust cache
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
+      - name: Run cargo check, failing on warnings
+        run: cargo check --profile ci --all-targets
+        # It'd be nice to fail on warnings, but we're not ready for that.
+        # env:
+        #   RUSTFLAGS: "-D warnings"
 
   test:
     name: Test Suite
@@ -36,7 +36,7 @@ jobs:
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
       - name: Run tests with nextest
-        run: cargo nextest run --features ${{ matrix.backend }}
+        run: cargo nextest run --cargo-profile ci --profile ci --features ${{ matrix.backend }}
         env:
           CARGO_TERM_COLOR: always
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,9 @@ required-features = ["arkworks"]
 name = "sqrt"
 harness = false
 required-features = ["arkworks"]
+
+# Create profile for running checks in CI that are mostly "release" mode,
+# but also checking the `debug_assert `lines.
+[profile.ci]
+inherits = "release"
+debug-assertions = true

--- a/benches/sqrt.rs
+++ b/benches/sqrt.rs
@@ -1,7 +1,7 @@
 use ark_ff::{Field, PrimeField, Zero};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use decaf377::Fq;
-use decaf377::{SqrtRatioZeta, ZETA};
+use decaf377::ZETA;
 use rand_chacha::ChaChaRng;
 use rand_core::{RngCore, SeedableRng};
 


### PR DESCRIPTION
We want to use the `--release` behavior, but doing so directly would disable evaluation of `debug_assert` lines, so we'll selectively override that one option.

Updates the "check" and "test" jobs to use the `--profile ci`. Also ensures that "check" covers all targets, including benchmarks, and accordingly cleans up an unused import in same.