### PR TITLE
Make raw constructors of field elements private

### DIFF
--- a/benches/sqrt.rs
+++ b/benches/sqrt.rs
@@ -1,4 +1,4 @@
-use ark_ff::{Field, PrimeField, Zero};
+use ark_ff::{Field, Zero};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use decaf377::Fq;
 use decaf377::ZETA;

--- a/src/fields/fp/u32/wrapper.rs
+++ b/src/fields/fp/u32/wrapper.rs
@@ -26,7 +26,7 @@ impl zeroize::Zeroize for Fp {
 }
 
 impl Fp {
-    pub fn from_le_limbs(limbs: [u64; N_64]) -> Fp {
+    pub(crate) fn from_le_limbs(limbs: [u64; N_64]) -> Fp {
         let limbs = {
             let mut out = [0u32; N];
             for i in 0..N_64 {
@@ -51,7 +51,7 @@ impl Fp {
         Self(x)
     }
 
-    pub fn to_le_limbs(&self) -> [u64; N_64] {
+    pub(crate) fn to_le_limbs(&self) -> [u64; N_64] {
         let mut x_non_montgomery = fiat::FpNonMontgomeryDomainFieldElement([0; N]);
         fiat::fp_from_montgomery(&mut x_non_montgomery, &self.0);
         let limbs = x_non_montgomery.0;
@@ -74,7 +74,7 @@ impl Fp {
         Self(fiat::FpMontgomeryDomainFieldElement(limbs))
     }
 
-    pub const fn from_montgomery_limbs(limbs: [u64; N_64]) -> Fp {
+    pub(crate) const fn from_montgomery_limbs(limbs: [u64; N_64]) -> Fp {
         Self(fiat::FpMontgomeryDomainFieldElement([
             limbs[0] as u32,
             (limbs[0] >> 32) as u32,

--- a/src/fields/fp/u64/wrapper.rs
+++ b/src/fields/fp/u64/wrapper.rs
@@ -26,7 +26,7 @@ impl zeroize::Zeroize for Fp {
 }
 
 impl Fp {
-    pub fn from_le_limbs(limbs: [u64; N_64]) -> Fp {
+    pub(crate) fn from_le_limbs(limbs: [u64; N_64]) -> Fp {
         let x_non_monty = fiat::FpNonMontgomeryDomainFieldElement(limbs);
         let mut x = fiat::FpMontgomeryDomainFieldElement([0; N]);
         fiat::fp_to_montgomery(&mut x, &x_non_monty);
@@ -43,7 +43,7 @@ impl Fp {
         Self(x)
     }
 
-    pub fn to_le_limbs(&self) -> [u64; N_64] {
+    pub(crate) fn to_le_limbs(&self) -> [u64; N_64] {
         let mut x_non_montgomery = fiat::FpNonMontgomeryDomainFieldElement([0; N]);
         fiat::fp_from_montgomery(&mut x_non_montgomery, &self.0);
         x_non_montgomery.0
@@ -57,7 +57,7 @@ impl Fp {
         bytes
     }
 
-    pub const fn from_montgomery_limbs(limbs: [u64; N]) -> Fp {
+    pub(crate) const fn from_montgomery_limbs(limbs: [u64; N]) -> Fp {
         Self(fiat::FpMontgomeryDomainFieldElement(limbs))
     }
 

--- a/src/fields/fq/u32/wrapper.rs
+++ b/src/fields/fq/u32/wrapper.rs
@@ -35,7 +35,7 @@ impl zeroize::Zeroize for Fq {
 }
 
 impl Fq {
-    pub fn from_le_limbs(limbs: [u64; N_64]) -> Fq {
+    pub(crate) fn from_le_limbs(limbs: [u64; N_64]) -> Fq {
         let limbs = {
             let mut out = [0u32; N];
             for i in 0..N_64 {
@@ -60,7 +60,7 @@ impl Fq {
         Self(x)
     }
 
-    pub fn to_le_limbs(&self) -> [u64; N_64] {
+    pub(crate) fn to_le_limbs(&self) -> [u64; N_64] {
         debug_assert!(!self.is_sentinel());
 
         let mut x_non_montgomery = fiat::FqNonMontgomeryDomainFieldElement([0; N]);
@@ -83,7 +83,7 @@ impl Fq {
         bytes
     }
 
-    pub const fn from_montgomery_limbs_backend(limbs: [u32; N]) -> Fq {
+    const fn from_montgomery_limbs_backend(limbs: [u32; N]) -> Fq {
         Self(fiat::FqMontgomeryDomainFieldElement(limbs))
     }
 

--- a/src/fields/fq/u64/wrapper.rs
+++ b/src/fields/fq/u64/wrapper.rs
@@ -35,7 +35,7 @@ impl zeroize::Zeroize for Fq {
 }
 
 impl Fq {
-    pub fn from_le_limbs(limbs: [u64; N_64]) -> Fq {
+    pub(crate) fn from_le_limbs(limbs: [u64; N_64]) -> Fq {
         let x_non_monty = fiat::FqNonMontgomeryDomainFieldElement(limbs);
         let mut x = fiat::FqMontgomeryDomainFieldElement([0; N]);
         fiat::fq_to_montgomery(&mut x, &x_non_monty);
@@ -52,7 +52,7 @@ impl Fq {
         Self(x)
     }
 
-    pub fn to_le_limbs(&self) -> [u64; N_64] {
+    pub(crate) fn to_le_limbs(&self) -> [u64; N_64] {
         debug_assert!(!self.is_sentinel());
 
         let mut x_non_montgomery = fiat::FqNonMontgomeryDomainFieldElement([0; N]);
@@ -70,7 +70,7 @@ impl Fq {
         bytes
     }
 
-    pub const fn from_montgomery_limbs(limbs: [u64; N]) -> Fq {
+    pub(crate) const fn from_montgomery_limbs(limbs: [u64; N]) -> Fq {
         Self(fiat::FqMontgomeryDomainFieldElement(limbs))
     }
 

--- a/src/fields/fr/u32/wrapper.rs
+++ b/src/fields/fr/u32/wrapper.rs
@@ -26,7 +26,7 @@ impl zeroize::Zeroize for Fr {
 }
 
 impl Fr {
-    pub fn from_le_limbs(limbs: [u64; N_64]) -> Fr {
+    pub(crate) fn from_le_limbs(limbs: [u64; N_64]) -> Fr {
         let limbs = {
             let mut out = [0u32; N];
             for i in 0..N_64 {
@@ -51,7 +51,7 @@ impl Fr {
         Self(x)
     }
 
-    pub fn to_le_limbs(&self) -> [u64; N_64] {
+    pub(crate) fn to_le_limbs(&self) -> [u64; N_64] {
         let mut x_non_montgomery = fiat::FrNonMontgomeryDomainFieldElement([0; N]);
         fiat::fr_from_montgomery(&mut x_non_montgomery, &self.0);
         let limbs = x_non_montgomery.0;
@@ -70,11 +70,11 @@ impl Fr {
         bytes
     }
 
-    pub const fn from_montgomery_limbs_backend(limbs: [u32; N]) -> Fr {
+    const fn from_montgomery_limbs_backend(limbs: [u32; N]) -> Fr {
         Self(fiat::FrMontgomeryDomainFieldElement(limbs))
     }
 
-    pub const fn from_montgomery_limbs(limbs: [u64; N_64]) -> Fr {
+    pub(crate) const fn from_montgomery_limbs(limbs: [u64; N_64]) -> Fr {
         Self::from_montgomery_limbs_backend([
             limbs[0] as u32,
             (limbs[0] >> 32) as u32,

--- a/src/fields/fr/u64/wrapper.rs
+++ b/src/fields/fr/u64/wrapper.rs
@@ -26,7 +26,7 @@ impl zeroize::Zeroize for Fr {
 }
 
 impl Fr {
-    pub fn from_le_limbs(limbs: [u64; N_64]) -> Fr {
+    pub(crate) fn from_le_limbs(limbs: [u64; N_64]) -> Fr {
         let x_non_monty = fiat::FrNonMontgomeryDomainFieldElement(limbs);
         let mut x = fiat::FrMontgomeryDomainFieldElement([0; N]);
         fiat::fr_to_montgomery(&mut x, &x_non_monty);
@@ -43,7 +43,7 @@ impl Fr {
         Self(x)
     }
 
-    pub fn to_le_limbs(&self) -> [u64; N_64] {
+    pub(crate) fn to_le_limbs(&self) -> [u64; N_64] {
         let mut x_non_montgomery = fiat::FrNonMontgomeryDomainFieldElement([0; N]);
         fiat::fr_from_montgomery(&mut x_non_montgomery, &self.0);
         x_non_montgomery.0
@@ -57,7 +57,7 @@ impl Fr {
         bytes
     }
 
-    pub const fn from_montgomery_limbs(limbs: [u64; N]) -> Fr {
+    pub(crate) const fn from_montgomery_limbs(limbs: [u64; N]) -> Fr {
         Self(fiat::FrMontgomeryDomainFieldElement(limbs))
     }
 

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -2,7 +2,7 @@ use core::convert::TryFrom;
 
 use proptest::prelude::*;
 
-use decaf377::{basepoint, Element, Encoding, FieldExt, Fq, Fr};
+use decaf377::{basepoint, Element, Encoding, Fq, Fr};
 
 /*
 #[test]
@@ -104,7 +104,7 @@ proptest! {
 
     #[test]
     fn fq_encoding_round_trip_if_successful(bytes: [u8; 32]) {
-        if let Ok(x) = Fq::from_bytes(bytes) {
+        if let Ok(x) = Fq::from_bytes_checked(&bytes) {
             let bytes2 = x.to_bytes();
             assert_eq!(bytes, bytes2);
         }
@@ -112,7 +112,7 @@ proptest! {
 
     #[test]
     fn scalar_encoding_round_trip_if_successful(bytes: [u8; 32]) {
-        if let Ok(x) = Fr::from_bytes(bytes) {
+        if let Ok(x) = Fr::from_bytes_checked(&bytes) {
             let bytes2 = x.to_bytes();
             assert_eq!(bytes, bytes2);
         }


### PR DESCRIPTION
The rationale here is that we only want the existing methods of constructing field elements, including from bytes.

There's an argument in favor of adding a constructor which takes in 64 bit limbs and reduces mod order, but that doesn't strike me as particularly necessary.