### PR TITLE
adjust anyhow scope and remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "decaf377"
 version = "0.8.0"
-authors = ["Henry de Valence <hdevalence@hdevalence.ca>", "redshiftzero <jen@penumbralabs.xyz>"]
+authors = [
+    "Henry de Valence <hdevalence@hdevalence.ca>",
+    "redshiftzero <jen@penumbralabs.xyz>",
+]
 description = "A prime-order group designed for use in SNARKs over BLS12-377"
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -11,46 +14,66 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # no-alloc, no-std
 cfg-if = "1.0"
-hex = { version ="=0.4.3", default-features = false }
-subtle = { version="2.5", default-features = false }
-tracing-subscriber = { version = "0.3", default-features = false }
+hex = { version = "=0.4.3", default-features = false }
+subtle = { version = "2.5", default-features = false }
 zeroize = { version = "1.7", default-features = false }
 # no-std
-anyhow = { version = "1.0", default-features = false }
-num-bigint = { version= "0.4.4", optional = true, default-features = false }
-hashbrown = "0.14.3"
-tracing = { version = "0.1", default-features = false }
+num-bigint = { version = "0.4.4", optional = true, default-features = false }
 # std
+hashbrown = { version = "0.14.3", optional = true }
 ark-relations = { version = "0.4", optional = true }
 ark-r1cs-std = { version = "0.4", optional = true }
 ark-std = { version = "0.4", optional = true }
 ark-ec = { version = "0.4", optional = true }
-ark-ff =  { version = "0.4", optional = true }
+ark-ff = { version = "0.4", optional = true }
 ark-serialize = { version = "0.4", optional = true }
 ark-bls12-377 = { version = "0.4", optional = true }
 ark-ed-on-bls12-377 = { version = "0.4", optional = true }
 ark-groth16 = { version = "0.4", optional = true }
 ark-snark = { version = "0.4", optional = true }
-once_cell = { version= "1.8", optional = true, default-features = false }
+once_cell = { version = "1.8", optional = true, default-features = false }
 
 # This matches what ark-std (a library for no_std compatibility) does, having
 # a default feature of std - without the ark-std std feature, decaf377 doesn't
 # compile
 [features]
 default = ["arkworks"]
-alloc = ["once_cell/alloc", "tracing-subscriber/alloc", "zeroize/alloc"]
-std = ["alloc", "tracing/std", "anyhow/std", "tracing-subscriber/std", "zeroize/std", "once_cell/std", "num-bigint/std", "hex/std", "subtle/std"]
-parallel = ["ark-ff/parallel", "ark-ec/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel"]
+alloc = ["once_cell/alloc", "zeroize/alloc"]
+std = [
+    "alloc",
+    "zeroize/std",
+    "once_cell/std",
+    "num-bigint/std",
+    "hex/std",
+    "subtle/std",
+]
+parallel = [
+    "ark-ff/parallel",
+    "ark-ec/parallel",
+    "ark-groth16/parallel",
+    "ark-std/parallel",
+    "ark-r1cs-std/parallel",
+]
 # TODO: eventually, feature-gate all arkworks deps behind this feature.
-arkworks = ["std", "ark-std", "ark-ec", "ark-ff", "ark-serialize", "ark-bls12-377", "ark-ed-on-bls12-377"]
+arkworks = [
+    "std",
+    "ark-std",
+    "ark-ec",
+    "ark-ff",
+    "ark-serialize",
+    "ark-bls12-377",
+    "ark-ed-on-bls12-377",
+    "hashbrown",
+]
 r1cs = ["arkworks", "ark-groth16", "ark-r1cs-std", "ark-relations", "ark-snark"]
 u32_backend = []
 
 [dev-dependencies]
 proptest = "1"
-criterion = { version = "0.3", features=["html_reports"] }
+criterion = { version = "0.3", features = ["html_reports"] }
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand_chacha = "0.3"
+anyhow = { version = "1.0" }
 
 [[test]]
 name = "encoding"


### PR DESCRIPTION
This PR introduces some adjustments to the `Cargo.toml` configuration to better align with the crate's compatibility and usage requirements, particularly focusing on the removal of the `tracing` dependency and the relocation of `anyhow` to dev-dependencies. These changes are motivated by the need to ensure compatibility with the `thumbv6m-none-eabi` target, which does not support atomic operations required by `tracing` and std/alloc. 

- **Removed `tracing` and `tracing-subscriber` Dependencies**: Due to incompatibility with the `thumbv6m-none-eabi` target, which lacks support for atomic operations, the `tracing` and `tracing-subscriber` dependencies have been removed. Besides that, the tracing dependencies are not used within the crate.

- **Relocated `anyhow` to Dev-Dependencies**: The `anyhow` crate is now moved to dev-dependencies, reflecting its usage strictly in development contexts and tests.

- **Minor Adjustments and Cleanup**: The PR also includes minor adjustments for consistency and clarity in the `Cargo.toml` file, such as formatting and the explicit inclusion of `hashbrown` under the `arkworks` feature flag(can be also put behind the std or alloc features).

With these changes, we can compile this crate for the `thumbv6m-non-eabi` target, by enabling the `u32_backend` and disabling `std` and `alloc` features.