### PR TITLE
Add useful convertion trait implementation

### DIFF
--- a/src/min_curve/encoding.rs
+++ b/src/min_curve/encoding.rs
@@ -1,2 +1,31 @@
+use crate::EncodingError;
+use core::convert::TryFrom;
+
 #[derive(Copy, Clone, Default, Eq, Ord, PartialOrd, PartialEq, Debug)]
 pub struct Encoding(pub [u8; 32]);
+
+impl TryFrom<&[u8]> for Encoding {
+    type Error = EncodingError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        if bytes.len() == 32 {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&bytes[0..32]);
+            Ok(Encoding(arr))
+        } else {
+            Err(EncodingError::InvalidSliceLength)
+        }
+    }
+}
+
+impl From<[u8; 32]> for Encoding {
+    fn from(bytes: [u8; 32]) -> Encoding {
+        Encoding(bytes)
+    }
+}
+
+impl From<Encoding> for [u8; 32] {
+    fn from(enc: Encoding) -> [u8; 32] {
+        enc.0
+    }
+}


### PR DESCRIPTION
The `no_std/alloc` counterpart for encoding was missing the `TryFrom` and `From` conversion implementations for `[u8; 32]`. This PR add those