### PR TITLE
wip: move rand_core requirement under std feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,6 @@
 * add power impl and expose `Fq::from_montgomery_limbs` by @redshiftzero in #98
 * Add missing conversion trait implementations by @neithanmo in #97
 
+# 0.10.0
+
+* Move random sampling methods under `std` feature by @redshiftzero in #100

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decaf377"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     "Henry de Valence <hdevalence@hdevalence.ca>",
     "redshiftzero <jen@penumbralabs.xyz>",
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 cfg-if = "1.0"
 hex = { version = "=0.4.3", default-features = false }
 subtle = { version = "2.5", default-features = false }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.6", default-features = false, optional=true }
 zeroize = { version = "1.7", default-features = false }
 # no-std
 num-bigint = { version = "0.4.4", optional = true, default-features = false }

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -1,4 +1,5 @@
 use cfg_if::cfg_if;
+#[cfg(feature = "std")]
 use rand_core::CryptoRngCore;
 
 use crate::EncodingError;
@@ -130,6 +131,7 @@ impl Fp {
         self.to_bytes_le()
     }
 
+    #[cfg(feature = "std")]
     /// Sample a random field element uniformly.
     pub fn rand<R: CryptoRngCore>(rng: &mut R) -> Self {
         // Sample wide, reduce

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -1,4 +1,5 @@
 use cfg_if::cfg_if;
+#[cfg(feature = "std")]
 use rand_core::CryptoRngCore;
 
 use crate::EncodingError;
@@ -115,6 +116,7 @@ impl Fq {
         self.to_bytes_le()
     }
 
+    #[cfg(feature = "std")]
     /// Sample a random field element uniformly.
     pub fn rand<R: CryptoRngCore>(rng: &mut R) -> Self {
         // Sample wide, reduce

--- a/src/fields/fr.rs
+++ b/src/fields/fr.rs
@@ -1,4 +1,5 @@
 use cfg_if::cfg_if;
+#[cfg(feature = "std")]
 use rand_core::CryptoRngCore;
 
 use crate::EncodingError;
@@ -107,6 +108,7 @@ impl Fr {
         self.to_bytes_le()
     }
 
+    #[cfg(feature = "std")]
     /// Sample a random field element uniformly.
     pub fn rand<R: CryptoRngCore>(rng: &mut R) -> Self {
         // Sample wide, reduce


### PR DESCRIPTION
I discovered when compiling `poseidon377` using `decaf377 0.9.0` on `thumbv8m.main-none-eabi` that the addition of `rand_core` in #91 caused a build failure. This is because `rand_core` requires `getrandom`, which in turn does not support the target `thumbv8m.main-none-eabi` (more deets here: https://docs.rs/getrandom/latest/getrandom/#unsupported-targets). This PR sidesteps that issue by moving the new methods requiring `rand_core` under the `std` feature flag. 