### PR TITLE
Fix infinite loops in small backend curve operations

### DIFF
--- a/src/min_curve/ops.rs
+++ b/src/min_curve/ops.rs
@@ -110,7 +110,7 @@ impl<'a, 'b> Mul<&'b Fr> for &'a Element {
     type Output = Element;
 
     fn mul(self, scalar: &'b Fr) -> Element {
-        scalar * self
+        *scalar * *self
     }
 }
 
@@ -118,7 +118,7 @@ impl<'a, 'b> Mul<&'b Element> for &'a Fr {
     type Output = Element;
 
     fn mul(self, point: &'b Element) -> Element {
-        point * self
+        *point * *self
     }
 }
 
@@ -142,7 +142,7 @@ impl<'b> Mul<&'b Element> for Fr {
     type Output = Element;
 
     fn mul(self, other: &'b Element) -> Element {
-        other * self
+        *other * self
     }
 }
 


### PR DESCRIPTION
In the multiplication implementations for `Element`, we accidentally forgot to dereference the references, leading to an infinite loop, as each multiplication implementation would never descend down to the actual implementation.