### PR TITLE
decaf377: arkworks v0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,16 @@ zeroize = { version = "1.7", default-features = false }
 num-bigint = { version = "0.4.4", optional = true, default-features = false }
 # std
 hashbrown = { version = "0.14.3", optional = true }
-ark-relations = { version = "0.4", optional = true }
-ark-r1cs-std = { version = "0.4", optional = true }
-ark-std = { version = "0.4", optional = true }
-ark-ec = { version = "0.4", optional = true }
-ark-ff = { version = "0.4", optional = true }
-ark-serialize = { version = "0.4", optional = true }
-ark-bls12-377 = { version = "0.4", optional = true }
-ark-ed-on-bls12-377 = { version = "0.4", optional = true }
-ark-groth16 = { version = "0.4", optional = true }
-ark-snark = { version = "0.4", optional = true }
+ark-relations = { version = "0.5", optional = true }
+ark-r1cs-std = { version = "0.5", optional = true }
+ark-std = { version = "0.5", optional = true }
+ark-ec = { version = "0.5", optional = true }
+ark-ff = { version = "0.5", optional = true }
+ark-serialize = { version = "0.5", optional = true }
+ark-bls12-377 = { version = "0.5", optional = true }
+ark-ed-on-bls12-377 = { version = "0.5", optional = true }
+ark-groth16 = { version = "0.5", optional = true }
+ark-snark = { version = "0.5", optional = true }
 once_cell = { version = "1.8", optional = true, default-features = false }
 
 # This matches what ark-std (a library for no_std compatibility) does, having

--- a/src/ark_curve/bls12_377.rs
+++ b/src/ark_curve/bls12_377.rs
@@ -5,7 +5,9 @@ use ark_ec::{
     models::CurveConfig,
     short_weierstrass::Affine,
 };
-use ark_ff::{fields::models::fp2::Fp2Config, Field, Fp12Config, Fp2, Fp6, Fp6Config};
+use ark_ff::{
+    fields::models::fp2::Fp2Config, AdditiveGroup, Field, Fp12Config, Fp2, Fp6, Fp6Config,
+};
 
 pub struct F2Config;
 

--- a/src/ark_curve/element/projective.rs
+++ b/src/ark_curve/element/projective.rs
@@ -1,14 +1,10 @@
-use core::borrow::Borrow;
-use core::hash::Hash;
-
+use super::super::constants::{B_T, B_X, B_Y, B_Z};
+use crate::{ark_curve::EdwardsProjective, Fq, Fr};
 use ark_ff::Zero;
 use ark_std::fmt::{Display, Formatter, Result as FmtResult};
-
+use core::borrow::Borrow;
+use core::hash::Hash;
 use zeroize::Zeroize;
-
-use crate::{ark_curve::EdwardsProjective, Fq, Fr};
-
-use super::super::constants::{B_T, B_X, B_Y, B_Z};
 
 #[derive(Copy, Clone)]
 pub struct Element {
@@ -23,6 +19,10 @@ impl Element {
 
     pub const IDENTITY: Self = Self {
         inner: EdwardsProjective::new_unchecked(Fq::ZERO, Fq::ONE, Fq::ZERO, Fq::ONE),
+    };
+
+    pub const ZERO: Self = Self {
+        inner: EdwardsProjective::new_unchecked(Fq::ZERO, Fq::ZERO, Fq::ZERO, Fq::ZERO),
     };
 }
 

--- a/src/ark_curve/on_curve.rs
+++ b/src/ark_curve/on_curve.rs
@@ -1,6 +1,6 @@
 use ark_ec::{
-    models::{twisted_edwards::Projective, twisted_edwards::TECurveConfig},
-    Group,
+    models::twisted_edwards::{Projective, TECurveConfig},
+    PrimeGroup,
 };
 use ark_ff::{BigInteger, Field, PrimeField, Zero};
 use ark_serialize::CanonicalSerialize;

--- a/src/ark_curve/ops/affine.rs
+++ b/src/ark_curve/ops/affine.rs
@@ -56,10 +56,10 @@ impl<'a, 'b> Sub<&'b AffinePoint> for &'a AffinePoint {
 }
 
 impl<'b> Sub<&'b AffinePoint> for AffinePoint {
-    type Output = AffinePoint;
+    type Output = Element;
 
-    fn sub(self, other: &'b AffinePoint) -> AffinePoint {
-        &self - other
+    fn sub(self, other: &'b AffinePoint) -> Element {
+        (&self - other).into()
     }
 }
 
@@ -72,9 +72,43 @@ impl<'a> Sub<AffinePoint> for &'a AffinePoint {
 }
 
 impl Sub<AffinePoint> for AffinePoint {
-    type Output = AffinePoint;
+    type Output = Element;
 
-    fn sub(self, other: AffinePoint) -> AffinePoint {
+    fn sub(self, other: AffinePoint) -> Element {
+        (&self - &other).into()
+    }
+}
+
+impl<'a, 'b> Sub<&'b Element> for &'a AffinePoint {
+    type Output = Element;
+
+    fn sub(self, other: &'b Element) -> Element {
+        Element {
+            inner: self.inner - other.inner,
+        }
+    }
+}
+
+impl<'b> Sub<&'b Element> for AffinePoint {
+    type Output = Element;
+
+    fn sub(self, other: &'b Element) -> Element {
+        &self - other
+    }
+}
+
+impl<'a> Sub<Element> for &'a AffinePoint {
+    type Output = Element;
+
+    fn sub(self, other: Element) -> Element {
+        self - &other
+    }
+}
+
+impl Sub<Element> for AffinePoint {
+    type Output = Element;
+
+    fn sub(self, other: Element) -> Element {
         &self - &other
     }
 }

--- a/src/ark_curve/ops/projective.rs
+++ b/src/ark_curve/ops/projective.rs
@@ -1,6 +1,5 @@
-use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-
 use crate::{ark_curve::element::projective::Element, ark_curve::AffinePoint, Fr};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 impl<'a, 'b> Add<&'b Element> for &'a Element {
     type Output = Element;
@@ -272,5 +271,59 @@ impl Sub<AffinePoint> for Element {
 
     fn sub(self, other: AffinePoint) -> Element {
         &self - &other.into()
+    }
+}
+
+impl<'a> Add<&'a mut Element> for Element {
+    type Output = Element;
+
+    fn add(self, other: &'a mut Self) -> Element {
+        Element {
+            inner: self.inner + other.inner,
+        }
+    }
+}
+
+impl<'a> Sub<&'a mut Element> for Element {
+    type Output = Element;
+
+    fn sub(self, other: &'a mut Element) -> Element {
+        Element {
+            inner: self.inner - other.inner,
+        }
+    }
+}
+
+impl<'a> AddAssign<&'a mut Element> for Element {
+    fn add_assign(&mut self, other: &'a mut Element) {
+        *self = Element {
+            inner: self.inner + other.inner,
+        }
+    }
+}
+
+impl<'a> SubAssign<&'a mut Element> for Element {
+    fn sub_assign(&mut self, other: &'a mut Element) {
+        *self = Element {
+            inner: self.inner - other.inner,
+        }
+    }
+}
+
+impl<'a> Mul<&'a mut Fr> for Element {
+    type Output = Element;
+
+    fn mul(self, point: &'a mut Fr) -> Self::Output {
+        let mut p = self.inner;
+        p *= *point;
+        Element { inner: p }
+    }
+}
+
+impl<'a> MulAssign<&'a mut Fr> for Element {
+    fn mul_assign(&mut self, point: &'a mut Fr) {
+        let mut p = self.inner;
+        p *= *point;
+        *self = Element { inner: p }
     }
 }

--- a/src/ark_curve/r1cs/element.rs
+++ b/src/ark_curve/r1cs/element.rs
@@ -9,12 +9,12 @@ use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, prelude::*, R1CSVar};
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use ark_std::vec::Vec;
 
+use super::inner::{Decaf377EdwardsVar, ScalarMultiply, ScalarMultiplyAssign};
 use crate::ark_curve::r1cs::{lazy::LazyElementVar, FqVar};
 use crate::ark_curve::{edwards::EdwardsAffine, r1cs::inner::ElementVar as InnerElementVar};
 use crate::ark_curve::{AffinePoint, Element};
 use crate::{Fq, Fr};
-
-use super::inner::{Decaf377EdwardsVar, ScalarMultiply, ScalarMultiplyAssign};
+use ark_r1cs_std::prelude::ToBitsGadget;
 
 #[derive(Clone, Debug)]
 /// Represents the R1CS equivalent of a `decaf377::Element`

--- a/src/ark_curve/r1cs/fqvar_ext.rs
+++ b/src/ark_curve/r1cs/fqvar_ext.rs
@@ -1,7 +1,9 @@
+use ark_ff::Field;
 use ark_r1cs_std::eq::EqGadget;
+use ark_r1cs_std::prelude::ToBitsGadget;
 use ark_r1cs_std::prelude::{AllocVar, Boolean, FieldVar};
 use ark_r1cs_std::select::CondSelectGadget;
-use ark_r1cs_std::{R1CSVar, ToBitsGadget};
+use ark_r1cs_std::R1CSVar;
 use ark_relations::r1cs::SynthesisError;
 
 use crate::ark_curve::{constants::ZETA, r1cs::FqVar};
@@ -16,6 +18,43 @@ pub trait FqVarExtension: Sized {
     fn is_negative(&self) -> Result<Boolean<Fq>, SynthesisError>;
     fn is_nonnegative(&self) -> Result<Boolean<Fq>, SynthesisError>;
     fn abs(self) -> Result<Self, SynthesisError>;
+}
+
+// The methods for logical operations (and, or, not) were moved from the Boolean
+// enum to helper functions in AllocatedBool. Consequently, we need to do some
+// cursed redirection for the the Boolean enum to delegate these operations to the
+// underlying AllocatedBool when applicable.
+fn not<F: Field>(boolean: &Boolean<F>) -> Result<Boolean<F>, SynthesisError> {
+    match boolean {
+        Boolean::Var(allocated) => Ok(Boolean::Var(allocated.not()?)),
+        Boolean::Constant(value) => Ok(Boolean::Constant(!value)),
+    }
+}
+
+fn and<F: Field>(a: &Boolean<F>, b: &Boolean<F>) -> Result<Boolean<F>, SynthesisError> {
+    match (a, b) {
+        // Both are AllocatedBool
+        (Boolean::Var(alloc_a), Boolean::Var(alloc_b)) => Ok(Boolean::Var(alloc_a.and(alloc_b)?)),
+        // Both are constant
+        (Boolean::Constant(val_a), Boolean::Constant(val_b)) => {
+            Ok(Boolean::Constant(*val_a & *val_b))
+        }
+        // One is constant, one is variable
+        (Boolean::Constant(true), other) | (other, Boolean::Constant(true)) => Ok(other.clone()),
+        (Boolean::Constant(false), _) | (_, Boolean::Constant(false)) => {
+            Ok(Boolean::Constant(false))
+        }
+    }
+}
+
+fn or<F: Field>(a: &Boolean<F>, b: &Boolean<F>) -> Result<Boolean<F>, SynthesisError> {
+    match (a, b) {
+        (Boolean::Var(alloc_a), Boolean::Var(alloc_b)) => Ok(Boolean::Var(alloc_a.or(alloc_b)?)),
+        (Boolean::Constant(val_a), Boolean::Constant(val_b)) => {
+            Ok(Boolean::Constant(*val_a | *val_b))
+        }
+        _ => Err(SynthesisError::Unsatisfiable),
+    }
 }
 
 impl FqVarExtension for FqVar {
@@ -55,27 +94,29 @@ impl FqVarExtension for FqVar {
         y_squared_var.conditional_enforce_equal(&den_var_inv, &in_case_1)?;
 
         // Case 3: `(false, 0)` if `den` is zero
-        let was_not_square_var = was_square_var.not();
-        let in_case_3 = was_not_square_var.and(&den_var_is_zero)?;
+
+        let was_not_square_var = not(&was_square_var)?;
+        let in_case_3 = and(&was_not_square_var, &den_var_is_zero)?;
         // Certify the return value y is 0 when we're in case 3.
         y_squared_var.conditional_enforce_equal(&FqVar::zero(), &in_case_3)?;
 
         // Case 4: `(false, sqrt(zeta*num/den))` if `num` and `den` are both nonzero and `num/den` is nonsquare;
         let zeta_var = FqVar::new_constant(cs, ZETA)?;
         let zeta_times_one_over_den_var = zeta_var * den_var_inv;
-        let in_case_4 = was_not_square_var.and(&den_var_is_zero.not())?;
+        let is_den_var_is_zero = not(&den_var_is_zero)?;
+        let in_case_4 = and(&was_not_square_var, &is_den_var_is_zero)?;
         // Certify the return value y is sqrt(zeta * 1/den)
         y_squared_var.conditional_enforce_equal(&zeta_times_one_over_den_var, &in_case_4)?;
 
         // Ensure that we are in case 1, 3, or 4.
-        let in_case = in_case_1.or(&in_case_3)?.or(&in_case_4)?;
+        let in_case = or(&in_case_1, &or(&in_case_3, &in_case_4)?)?;
         in_case.enforce_equal(&Boolean::TRUE)?;
 
         Ok((was_square_var, y_var))
     }
 
     fn is_negative(&self) -> Result<Boolean<Fq>, SynthesisError> {
-        Ok(self.is_nonnegative()?.not())
+        Ok(not(&self.is_nonnegative()?)?)
     }
 
     fn is_nonnegative(&self) -> Result<Boolean<Fq>, SynthesisError> {
@@ -86,7 +127,7 @@ impl FqVarExtension for FqVar {
         let false_var = Boolean::<Fq>::FALSE;
 
         // Check least significant bit
-        let lhs = bitvars[0].and(&true_var)?;
+        let lhs = and(&bitvars[0], &true_var)?;
         let is_nonnegative_var = lhs.is_eq(&false_var)?;
 
         Ok(is_nonnegative_var)

--- a/src/ark_curve/r1cs/fqvar_ext.rs
+++ b/src/ark_curve/r1cs/fqvar_ext.rs
@@ -24,14 +24,14 @@ pub trait FqVarExtension: Sized {
 // enum to helper functions in AllocatedBool. Consequently, we need to do some
 // cursed redirection for the the Boolean enum to delegate these operations to the
 // underlying AllocatedBool when applicable.
-fn not<F: Field>(boolean: &Boolean<F>) -> Result<Boolean<F>, SynthesisError> {
+pub fn not<F: Field>(boolean: &Boolean<F>) -> Result<Boolean<F>, SynthesisError> {
     match boolean {
         Boolean::Var(allocated) => Ok(Boolean::Var(allocated.not()?)),
         Boolean::Constant(value) => Ok(Boolean::Constant(!value)),
     }
 }
 
-fn and<F: Field>(a: &Boolean<F>, b: &Boolean<F>) -> Result<Boolean<F>, SynthesisError> {
+pub fn and<F: Field>(a: &Boolean<F>, b: &Boolean<F>) -> Result<Boolean<F>, SynthesisError> {
     match (a, b) {
         // Both are AllocatedBool
         (Boolean::Var(alloc_a), Boolean::Var(alloc_b)) => Ok(Boolean::Var(alloc_a.and(alloc_b)?)),
@@ -47,7 +47,7 @@ fn and<F: Field>(a: &Boolean<F>, b: &Boolean<F>) -> Result<Boolean<F>, Synthesis
     }
 }
 
-fn or<F: Field>(a: &Boolean<F>, b: &Boolean<F>) -> Result<Boolean<F>, SynthesisError> {
+pub fn or<F: Field>(a: &Boolean<F>, b: &Boolean<F>) -> Result<Boolean<F>, SynthesisError> {
     match (a, b) {
         (Boolean::Var(alloc_a), Boolean::Var(alloc_b)) => Ok(Boolean::Var(alloc_a.or(alloc_b)?)),
         (Boolean::Constant(val_a), Boolean::Constant(val_b)) => {

--- a/src/ark_curve/r1cs/inner.rs
+++ b/src/ark_curve/r1cs/inner.rs
@@ -16,6 +16,7 @@ use ark_std::vec::Vec;
 use core::borrow::Borrow;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 pub(crate) type Decaf377EdwardsVar = AffineVar<Decaf377EdwardsConfig, FqVar>;
+use ark_r1cs_std::prelude::ToBitsGadget;
 
 #[derive(Clone, Debug)]
 /// Represents the R1CS equivalent of a `decaf377::Element`

--- a/src/fields/fp/arkworks.rs
+++ b/src/fields/fp/arkworks.rs
@@ -167,35 +167,6 @@ impl Field for Fp {
         sum
     }
 
-    fn frobenius_map(&self, power: usize) -> Self {
-        let mut this = *self;
-        this.frobenius_map_in_place(power);
-        this
-    }
-
-    fn pow<S: AsRef<[u64]>>(&self, exp: S) -> Self {
-        let mut res = Self::one();
-
-        for i in ark_ff::BitIteratorBE::without_leading_zeros(exp) {
-            res.square_in_place();
-
-            if i {
-                res *= self;
-            }
-        }
-        res
-    }
-
-    fn pow_with_table<S: AsRef<[u64]>>(powers_of_2: &[Self], exp: S) -> Option<Self> {
-        let mut res = Self::one();
-        for (pow, bit) in ark_ff::BitIteratorLE::without_trailing_zeros(exp).enumerate() {
-            if bit {
-                res *= powers_of_2.get(pow)?;
-            }
-        }
-        Some(res)
-    }
-
     fn mul_by_base_prime_field(&self, _elem: &Self::BasePrimeField) -> Self {
         unimplemented!()
     }

--- a/src/fields/fp/arkworks.rs
+++ b/src/fields/fp/arkworks.rs
@@ -145,28 +145,7 @@ impl Field for Fp {
         Self::from_random_bytes_with_flags::<EmptyFlags>(bytes).map(|f| f.0)
     }
 
-    fn sqrt(&self) -> Option<Self> {
-        match Self::SQRT_PRECOMP {
-            Some(tv) => tv.sqrt(self),
-            None => core::unimplemented!(),
-        }
-    }
-
-    fn sqrt_in_place(&mut self) -> Option<&mut Self> {
-        (*self).sqrt().map(|sqrt| {
-            *self = sqrt;
-            self
-        })
-    }
-
-    fn sum_of_products<const T: usize>(a: &[Self; T], b: &[Self; T]) -> Self {
-        let mut sum = Self::zero();
-        for i in 0..a.len() {
-            sum += a[i] * b[i];
-        }
-        sum
-    }
-
+    // Stub
     fn mul_by_base_prime_field(&self, _elem: &Self::BasePrimeField) -> Self {
         unimplemented!()
     }

--- a/src/fields/fp/arkworks.rs
+++ b/src/fields/fp/arkworks.rs
@@ -185,22 +185,6 @@ impl AdditiveGroup for Fp {
     type Scalar = Self;
 
     const ZERO: Self = Self::ZERO;
-
-    fn double(&self) -> Self {
-        let mut copy = *self;
-        copy.double_in_place();
-        copy
-    }
-
-    fn double_in_place(&mut self) -> &mut Self {
-        self.add_assign(*self);
-        self
-    }
-
-    fn neg_in_place(&mut self) -> &mut Self {
-        *self = -(*self);
-        self
-    }
 }
 
 impl Zero for Fp {

--- a/src/fields/fp/ops.rs
+++ b/src/fields/fp/ops.rs
@@ -43,6 +43,36 @@ impl From<bool> for Fp {
     }
 }
 
+impl From<i8> for Fp {
+    fn from(other: i8) -> Self {
+        i128::from(other).into()
+    }
+}
+
+impl From<i16> for Fp {
+    fn from(other: i16) -> Self {
+        i128::from(other).into()
+    }
+}
+
+impl From<i32> for Fp {
+    fn from(other: i32) -> Self {
+        i128::from(other).into()
+    }
+}
+
+impl From<i64> for Fp {
+    fn from(other: i64) -> Self {
+        i128::from(other).into()
+    }
+}
+
+impl From<i128> for Fp {
+    fn from(other: i128) -> Self {
+        i128::from(other).into()
+    }
+}
+
 impl Neg for Fp {
     type Output = Self;
 

--- a/src/fields/fq/arkworks.rs
+++ b/src/fields/fq/arkworks.rs
@@ -159,22 +159,6 @@ impl AdditiveGroup for Fq {
     type Scalar = Self;
 
     const ZERO: Self = Self::ZERO;
-
-    fn double(&self) -> Self {
-        let mut copy = *self;
-        copy.double_in_place();
-        copy
-    }
-
-    fn double_in_place(&mut self) -> &mut Self {
-        self.add_assign(*self);
-        self
-    }
-
-    fn neg_in_place(&mut self) -> &mut Self {
-        *self = -(*self);
-        self
-    }
 }
 
 impl Zero for Fq {

--- a/src/fields/fq/ops.rs
+++ b/src/fields/fq/ops.rs
@@ -43,6 +43,36 @@ impl From<bool> for Fq {
     }
 }
 
+impl From<i8> for Fq {
+    fn from(other: i8) -> Self {
+        i128::from(other).into()
+    }
+}
+
+impl From<i16> for Fq {
+    fn from(other: i16) -> Self {
+        i128::from(other).into()
+    }
+}
+
+impl From<i32> for Fq {
+    fn from(other: i32) -> Self {
+        i128::from(other).into()
+    }
+}
+
+impl From<i64> for Fq {
+    fn from(other: i64) -> Self {
+        i128::from(other).into()
+    }
+}
+
+impl From<i128> for Fq {
+    fn from(other: i128) -> Self {
+        i128::from(other).into()
+    }
+}
+
 impl Neg for Fq {
     type Output = Self;
 

--- a/src/fields/fr/arkworks.rs
+++ b/src/fields/fr/arkworks.rs
@@ -161,22 +161,6 @@ impl AdditiveGroup for Fr {
     type Scalar = Self;
 
     const ZERO: Self = Self::ZERO;
-
-    fn double(&self) -> Self {
-        let mut copy = *self;
-        copy.double_in_place();
-        copy
-    }
-
-    fn double_in_place(&mut self) -> &mut Self {
-        self.add_assign(*self);
-        self
-    }
-
-    fn neg_in_place(&mut self) -> &mut Self {
-        *self = -(*self);
-        self
-    }
 }
 
 impl Zero for Fr {

--- a/src/fields/fr/ops.rs
+++ b/src/fields/fr/ops.rs
@@ -43,6 +43,36 @@ impl From<bool> for Fr {
     }
 }
 
+impl From<i8> for Fr {
+    fn from(other: i8) -> Self {
+        i128::from(other).into()
+    }
+}
+
+impl From<i16> for Fr {
+    fn from(other: i16) -> Self {
+        i128::from(other).into()
+    }
+}
+
+impl From<i32> for Fr {
+    fn from(other: i32) -> Self {
+        i128::from(other).into()
+    }
+}
+
+impl From<i64> for Fr {
+    fn from(other: i64) -> Self {
+        i128::from(other).into()
+    }
+}
+
+impl From<i128> for Fr {
+    fn from(other: i128) -> Self {
+        i128::from(other).into()
+    }
+}
+
 impl Neg for Fr {
     type Output = Self;
 

--- a/tests/groth16_gadgets.rs
+++ b/tests/groth16_gadgets.rs
@@ -1,11 +1,9 @@
-use ark_ff::UniformRand;
 use ark_groth16::{r1cs_to_qap::LibsnarkReduction, Groth16, Proof, ProvingKey, VerifyingKey};
 use proptest::prelude::*;
 
 use ark_r1cs_std::{
-    prelude::{AllocVar, CurveVar, EqGadget},
+    prelude::{AllocVar, CurveVar, EqGadget, ToBitsGadget},
     uint8::UInt8,
-    ToBitsGadget,
 };
 use ark_relations::r1cs::{ConstraintSynthesizer, ToConstraintField};
 use ark_snark::SNARK;


### PR DESCRIPTION
Upgrade arkworks dependencies to` v0.5` in decaf377

enabling the `r1cs` flag as [default](https://github.com/penumbra-zone/decaf377/blob/95eb130bfe17ba33461c51f518d7bf15af13cfcc/Cargo.toml#L41) tested that the feature-gated r1cs tests pass as well.